### PR TITLE
minor fix for plugin detail popup and deactivation

### DIFF
--- a/bibleup.php
+++ b/bibleup.php
@@ -1,11 +1,11 @@
 <?php
 /*
    Plugin Name: BibleUp
-   Plugin URI: https://bibleup.netlify.com
+   Plugin URI: https://bibleup.netlify.app
    description: BibleUp transforms Bible References on a webpage into flexible, and highly customisable popovers.
    Version: 1.0.1
    Author: BibleUp
-   Author URI: https://bibleup.netlify.com
+   Author URI: https://bibleup.netlify.app
    License: GPLv3
    License URI: https://www.gnu.org/licenses/gpl-3.0.html
    */
@@ -158,7 +158,7 @@ class BibleUp {
 		return $r;
 	}
 
-	function bibleup_deactivate() {
+	public static function bibleup_deactivate() {
 		// Delete all saved settings from option group - bibleup
 		wpsf_delete_settings_bibleup( 'bibleup' );
 	}

--- a/wp-settings-framework/wp-settings-framework.php
+++ b/wp-settings-framework/wp-settings-framework.php
@@ -346,7 +346,11 @@ if ( ! class_exists( 'Bibleup_WordPressSettingsFramework' ) ) {
 										if ( $link && 'tooltip' === $link_type ) {
 											$tooltip = $link;
 										} elseif ( $link ) {
-											$field['subtitle'] .= ( empty( $field['subtitle'] ) ) ? $link : sprintf( '<br/><br/>%s', $link );
+											if ( isset( $field['subtitle'] ) ) {
+												$field['subtitle'] .= ( empty( $field['subtitle'] ) ) ? $link : sprintf( '<br/><br/>%s', $link );
+											} else {
+												$field['subtitle'] = $link;
+											}
 										}
 									}
 


### PR DESCRIPTION
Some minor fixes:
1. change the url from https://bibleup.netlify.com to https://bibleup.netlify.app 
2. add a null checker to prevent the warning
```
Warning: Undefined array key "subtitle" in /var/www/html/wp-content/plugins/bibleup/wp-settings-framework/wp-settings-framework.php on line 349
```
3.  deactivation failed on Wordpress 6.5+PHP8.2, so add public static to fix the deactivation error:
```
Fatal error: Uncaught TypeError: call_user_func_array(): Argument #1 ($callback) must be a valid callback, non-static method BibleUp::bibleup_deactivate() cannot be called statically in /var/www/html/wp-includes/class-wp-hook.php:324 Stack trace: #0 /var/www/html/wp-includes/class-wp-hook.php(348): WP_Hook->apply_filters('', Array) #1 /var/www/html/wp-includes/plugin.php(517): WP_Hook->do_action(Array) #2 /var/www/html/wp-admin/includes/plugin.php(828): do_action('deactivate_bibl...', false) #3 /var/www/html/wp-admin/plugins.php(211): deactivate_plugins('bibleup/bibleup...', false, false) #4 {main} thrown in /var/www/html/wp-includes/class-wp-hook.php on line 324
There has been a critical error on this website. Please check your site admin email inbox for instructions.
```
<img width="1218" alt="Screenshot 2024-05-25 at 6 40 01 AM" src="https://github.com/bibleup/wordpress/assets/8908273/5cf292a6-866c-46f4-8af7-b92d0b7701c9">

